### PR TITLE
Update Dockerfile - Bitcoin Core 0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN set -ex \
     && apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu gpg wget \
     && rm -rf /var/lib/apt/lists/*
 
-ENV BITCOIN_VERSION 0.15.1
-ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.15.1/bitcoin-0.15.1-x86_64-linux-gnu.tar.gz
-ENV BITCOIN_SHA256 387c2e12c67250892b0814f26a5a38f837ca8ab68c86af517f975a2a2710225b
-ENV BITCOIN_ASC_URL https://bitcoin.org/bin/bitcoin-core-0.15.1/SHA256SUMS.asc
+ENV BITCOIN_VERSION 0.16.0
+ENV BITCOIN_URL https://bitcoin.org/bin/bitcoin-core-0.16.0/bitcoin-0.16.0-x86_64-linux-gnu.tar.gz
+ENV BITCOIN_SHA256 e6322c69bcc974a29e6a715e0ecb8799d2d21691d683eeb8fef65fc5f6a66477
+ENV BITCOIN_ASC_URL https://bitcoin.org/bin/bitcoin-core-0.16.0/SHA256SUMS.asc
 ENV BITCOIN_PGP_KEY 01EA5486DE18A882D4C2684590C8019E36C2E964
 
 # install bitcoin binaries


### PR DESCRIPTION
Update Dockerfile to latest version of Bitcoin Core 0.16.0 released on 26-Feb-2018 07:33