### PR TITLE
bootstrap.dat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,9 @@ COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 8332 8333 18332 18333
-CMD ["bitcoind -loadblock=/root/.bitcoin/bootstrap.dat"]
+
+COPY start.sh start.sh
+
+RUN chmod +x start.sh
+
+CMD [ "/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 8332 8333 18332 18333
-CMD ["bitcoind"]
+CMD ["bitcoind -loadblock=/root/.bitcoin/bootstrap.dat"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" ]]; then
+if [[ "$1" == "bitcoin-cli" || "$1" == "bitcoin-tx" || "$1" == "bitcoind" || "$1" == "test_bitcoin" || "$1" == "start.sh" || "$1" == "/start.sh" ]]; then
     mkdir -p "$BITCOIN_DATA"
 
     if [[ ! -s "$BITCOIN_DATA/bitcoin.conf" ]]; then

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/local/bin/bitcoind -loadblock=/root/.bitcoin/bootstrap.dat

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/usr/local/bin/bitcoind -loadblock=/root/.bitcoin/bootstrap.dat
+/usr/local/bin/bitcoind -loadblock=/data/bootstrap.dat


### PR DESCRIPTION
added support for bootstrap.dat

you can also use symlinks to load bootstrap off different hard drive or mounted network storage just make sure to add the destination of the symlink to the run command  

`   -v /mnt/disk2:/mnt/disk2 `

success, well its still loading but it tells me its doing it.... :) 

> 2018-11-09T17:36:06Z [default wallet] mapAddressBook.size() = 0
> 2018-11-09T17:36:06Z **Importing bootstrap.dat...**
> 2018-11-09T17:36:06Z UpdateTip: new best=000000000
> 


