### PR TITLE
Adding --no-tty for gpg in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN set -ex \
     && wget -q https://bitcoin.org/laanwj-releases.asc \
     && SHA256=`grep "${BITCOIN_ARCHIVE}" SHA256SUMS.asc | awk '{print $1}'` \
     && echo "$SHA256 ${BITCOIN_ARCHIVE}" | sha256sum -c - \
-    && gpg --import ./laanwj-releases.asc \
-    && gpg --verify SHA256SUMS.asc \
+    && gpg --no-tty --import ./laanwj-releases.asc \
+    && gpg --no-tty --verify SHA256SUMS.asc \
     && tar -xzf ${BITCOIN_ARCHIVE} -C /usr/local --strip-components=1 --exclude=*-qt \
     && rm -rf /tmp/* \
     && bitcoind --version    


### PR DESCRIPTION
When running docker build on Centos 7 I was getting errors about no /dev/tty. In researching the error I found that adding --no-tty to the gpg lines in the Dockerfile solved this for me. Since we are assuming no output and using && to validate the files downloaded then no output should be ok.